### PR TITLE
feat: implement Experience and Skills sections with localization support

### DIFF
--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -79,7 +79,7 @@ export default function Header({ t, language, setLanguage, onNavigate }) {
         <Box sx={{ display: 'flex', gap: 2 }}>
           <Button color="inherit" component={Link} href="/">{t.header.about}</Button>
            <Button color="inherit" component={Link} href="/education">{t.header.education}</Button>
-          <Button color="inherit" onClick={() => onNavigate('experience')}>{t.header.experience}</Button>
+          <Button color="inherit" component={Link} href="/experiences">{t.header.experience}</Button>
           <Button color="inherit" onClick={() => onNavigate('articles')}>{t.header.articles}</Button>
           <Button color="inherit" onClick={() => onNavigate('repositories')}>{t.header.repositories}</Button>
         </Box>

--- a/components/molecules/ExperienceCard.js
+++ b/components/molecules/ExperienceCard.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import WorkIcon from '@mui/icons-material/Work';
+import Divider from '@mui/material/Divider';
+
+/**
+ * Componente para exibir informações de uma experiência profissional.
+ * Props:
+ * - cargo: nome do cargo
+ * - startYear: ano de início
+ * - endYear: ano de término
+ * - empresa: nome da empresa
+ * - estado: estado da empresa
+ * - resumo: breve resumo do cargo
+ */
+import Grid from '@mui/material/Grid';
+
+const ExperienceCard = ({ cargo, startYear, endYear, empresa, estado, resumo }) => (
+  <Card
+    sx={{
+      width: '100%',
+      minWidth: 280,
+      maxWidth: '100%',
+      borderRadius: 4,
+      boxShadow: 6,
+      borderLeft: '8px solid',
+      borderColor: 'primary.main',
+      transition: 'box-shadow 0.3s',
+      ':hover': {
+        boxShadow: 12,
+      },
+      backgroundColor: '#fff',
+      marginBottom: 3,
+      display: 'flex',
+      flexDirection: 'column',
+    }}
+  >
+    {/* Seção 1: Topo - Cargo */}
+    <Box sx={{ display: 'flex', alignItems: 'center', p: 2, pb: 1, borderTopLeftRadius: 4, borderTopRightRadius: 4 }}>
+      <WorkIcon color="primary" sx={{ fontSize: 32, mr: 1 }} />
+      <Typography variant="h6" sx={{ fontWeight: 700 }}>
+        {cargo} | {startYear} - {endYear}
+      </Typography>
+    </Box>
+    <Divider />
+    {/* Seção 2: Grid principal */}
+    <Box sx={{ display: 'flex', flexDirection: 'row', px: 2, py: 2, gap: 2, alignItems: 'center' }}>
+      {/* Coluna 1: Empresa, estado, datas */}
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1, justifyContent: 'center', height: '100%' }}>
+        <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 600 }}>
+          {empresa}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {estado}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {startYear} - {endYear}
+        </Typography>
+      </Box>
+      {/* Coluna 2: Resumo */}
+      <Box sx={{ flex: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {Array.isArray(resumo)
+          ? resumo.map((item, idx) => (
+              <Typography key={idx} variant="body2" color="text.primary" paragraph>
+                {item}
+              </Typography>
+            ))
+          : <Typography variant="body2" color="text.primary">{resumo}</Typography>
+        }
+      </Box>
+    </Box>
+  </Card>
+);
+
+
+export default ExperienceCard;

--- a/components/sections/Experience.js
+++ b/components/sections/Experience.js
@@ -1,15 +1,34 @@
 import * as React from 'react';
 import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import ExperienceCard from '../molecules/ExperienceCard';
 
-export default function Experience({ t }) {
+export default function Experience({ t, experienceList = [] }) {
   return (
-    <>
-      <Typography variant="h5" sx={{ mt: 2 }}>
-        {t.experience.title}
-      </Typography>
-      <Typography variant="body1" sx={{ mt: 1 }}>
-        {t.experience.description}
-      </Typography>
-    </>
+    <Box display="flex" flexDirection="column" alignItems="center" width="100%" sx={{ gap: 3, px: 2 }}>
+
+
+     {experienceList.length === 0 ? (
+         <Typography variant="body2" color="text.secondary">Nenhuma formação encontrada.</Typography>
+       ) : (
+         <Box sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+           <Grid container spacing={3} maxWidth={900} justifyContent="center">
+             {experienceList.map((edu, idx) => (
+               <Grid item xs={12} md={6} key={idx}>
+                 <ExperienceCard
+                   cargo={edu.position}
+                   startYear={edu.startDate}
+                   endYear={edu.endDate}
+                   empresa={edu.company}
+                   estado={edu.state}
+                   resumo={edu.descriptions}
+                 />
+               </Grid>
+             ))}
+           </Grid>
+         </Box>
+       )}
+    </Box>
   );
 }

--- a/components/sections/HadSkills.js
+++ b/components/sections/HadSkills.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import BuildIcon from '@mui/icons-material/Build';
+import Button from '@mui/material/Button';
+import DownloadIcon from '@mui/icons-material/Download';
+
+export default function Skills({ t, skillsList = [] }) {
+  return (
+    <Box width="100%" sx={{ mt: 6, px: 2, display: 'flex', justifyContent: 'center' }}>
+      <Card sx={{ width: '100%', maxWidth: 900, borderRadius: 4, boxShadow: 6, backgroundColor: '#fff', mx: 'auto' }}>
+        <CardContent sx={{ px: { xs: 2, sm: 4 }, py: { xs: 2, sm: 4 } }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
+  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+    <BuildIcon color="primary" sx={{ fontSize: 36, mr: 2 }} />
+    <Typography
+      variant="h5"
+      sx={{
+        fontWeight: 700,
+        background: 'linear-gradient(90deg, #1976d2 0%, #000 100%)',
+        WebkitBackgroundClip: 'text',
+        WebkitTextFillColor: 'transparent',
+        backgroundClip: 'text',
+        textFillColor: 'transparent',
+        fontSize: { xs: 28, sm: 36 },
+      }}
+    >
+      {t['hardSkills'] || 'Habilidades'}
+    </Typography>
+  </Box>
+</Box>
+          {skillsList.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">Nenhuma skill encontrada.</Typography>
+          ) : (
+            <Grid container spacing={3} justifyContent="center">
+              {skillsList.map((skill, idx) => (
+                <Grid item xs={12} sm={4} md={4} key={idx} sx={{ display: 'flex', justifyContent: 'center' }}>
+                  <Chip label={skill} color="primary" variant="outlined" sx={{ fontSize: 18, px: 2, py: 2, height: 48, transition: 'all 0.2s', cursor: 'pointer', '&:hover': { boxShadow: 4, transform: 'scale(1.08)', background: 'linear-gradient(90deg, #1976d2 0%, #000 100%)', color: '#fff', border: 'none' } }} />
+                </Grid>
+              ))}
+            </Grid>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/pages/experiences.js
+++ b/pages/experiences.js
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import DownloadIcon from '@mui/icons-material/Download';
+import { MongoOperator } from '../lib/mongodb';
+import Experience from '../components/sections/Experience';
+import Skills from '../components/sections/HadSkills';
+import Header from '../components/layout/Header';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import { useState, useEffect } from 'react';
+
+export async function getStaticProps() {
+  const host = process.env.MONGODB_URI;
+  const dbName = process.env.MONGODB_DB;
+  const mongo = new MongoOperator(host, dbName);
+  let skillsList = [];
+  let experiencesList = [];
+  try {
+    skillsList = await mongo.findAll('Skills');
+    experiencesList = await mongo.findAll('Experiencia');
+    await mongo.closeConnection();
+  } catch (err) {
+    skillsList = [];
+    experiencesList = [];
+  }
+  return {
+    props: {
+      skillsList: JSON.parse(JSON.stringify(skillsList)),
+      experiencesList: JSON.parse(JSON.stringify(experiencesList)),
+    },
+    revalidate: 60,
+  };
+}
+
+function useTranslations(language) {
+  const [t, setT] = useState(null);
+  useEffect(() => {
+    fetch(`/locales/${language}.json`)
+      .then((res) => res.json())
+      .then(setT);
+  }, [language]);
+  return t;
+}
+
+
+
+export default function ExperiencesPage({ experiencesList, skillsList }) {
+  const [language, setLanguage] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const browserLang = navigator.language.slice(0, 2);
+      return ['pt', 'en'].includes(browserLang) ? browserLang : 'pt';
+    }
+    return 'pt';
+  });
+  const t = useTranslations(language);
+
+  if (!t) return <div>Carregando...</div>;
+
+  // Filtra a lista de experiências e skills pelo idioma selecionado
+  const languageExperiences = language === 'pt' ? 'pt/Br' : 'en/Us';
+  const filteredExperiencesList = experiencesList.filter(exp => exp.lang === languageExperiences);
+  const softSkillsList = skillsList[0]['Softskills']
+
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <Header
+        t={t}
+        language={language}
+        setLanguage={setLanguage}
+        onNavigate={() => { }}
+      />
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', mt: 8, gap: 2 }}>
+        <Box sx={{ width: '100%', maxWidth: 900, mx: 'auto', mb: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 4 }}>
+            <Typography
+              variant="h3"
+              sx={{
+                fontWeight: 800,
+                background: 'linear-gradient(90deg, #1976d2 0%, #000 100%)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                backgroundClip: 'text',
+                textFillColor: 'transparent',
+                fontSize: { xs: 32, sm: 48 },
+              }}
+            >
+              {t['pageTitle']['experience'] || 'Experiências'}
+            </Typography>
+            <Button
+              variant="contained"
+              color="primary"
+              endIcon={<DownloadIcon />}
+              sx={{ fontWeight: 600, fontSize: 16, px: 3, py: 1, borderRadius: 2, boxShadow: 2 }}
+              href={
+                language === 'pt'
+                  ? "https://drive.google.com/file/d/1W3T35gdR0fGq8hHb2xgqB7sbXOA8nTFX/view"
+                  : "https://drive.google.com/file/d/1d3gFlEXhrFObIvd_BOgk9JSa0pHpO3wT/view"
+              }
+              target="_blank"
+            >
+              Download CV
+            </Button>
+          </Box>
+          <Box sx={{ width: '100%', maxWidth: 900, my: 2 }}>
+            <Divider sx={{ borderColor: 'rgba(128,128,128,0.15)', borderWidth: 1, borderRadius: 2 }} />
+          </Box>
+        </Box>
+        {/* Cards de Experiência */}
+        <Box sx={{ width: '100%', maxWidth: 900, mx: 'auto', my: 4, display: 'flex', flexWrap: 'wrap', gap: 3, justifyContent: 'center' }}>
+          <Box sx={{ width: '100%', maxWidth: 900, my: 2 }}>
+            <Experience t={t} experienceList={filteredExperiencesList} />
+            <Divider sx={{ borderColor: 'rgba(128,128,128,0.15)', borderWidth: 1, borderRadius: 2 }} />
+          </Box>
+
+
+        </Box>
+        <Skills t={t} skillsList={softSkillsList} />
+      </Box>
+    </Box>
+  );
+}

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -40,5 +40,8 @@
   "repositories": {
     "title": "Repositories",
     "description": "Open source projects available on my GitHub."
-  }
+  },
+  
+  "softSkills": "Skills",
+  "hardSkills": "Professional Skills"
 }

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -44,5 +44,7 @@
   "repositories": {
     "title": "Repositórios",
     "description": "Projetos open source disponíveis no meu GitHub."
-  }
+  },
+  "softSkills": "Skills",
+  "hardSkills": "Professional Skills"
 }


### PR DESCRIPTION
## Descrição do Pull Request

### Resumo das mudanças

• Implementa as seções de Experiência e Skills na aplicação, com suporte à localização
(português e inglês).
• Adiciona a página /experiences que exibe experiências profissionais e habilidades, integrando
dados do MongoDB.
• Cria os componentes ExperienceCard e HadSkills para exibição visual das experiências e
habilidades.
• Atualiza o Header para incluir navegação para a nova página de experiências.
• Melhora os arquivos de localização (en.json e pt.json) com novas chaves para as seções de
skills.
• Refatora o componente de experiência para receber e exibir uma lista dinâmica de experiências.
• Adiciona botão para download do CV em português e inglês.

### Motivação

Essas mudanças visam enriquecer o portfólio com uma seção dedicada à trajetória profissional e
habilidades, tornando o site mais completo e atrativo para recrutadores e visitantes. O suporte
à localização garante acessibilidade para diferentes públicos.

### Impacto

• Nova página de experiências disponível no menu.
• Visualização aprimorada das experiências e habilidades.
• Suporte multilíngue para as novas seções.
• Integração com dados dinâmicos do MongoDB.
